### PR TITLE
Fix footer background

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -92,7 +92,7 @@
             </div>
         </section>
         <!-- Footer-->
-        <footer class="py-5 bg-black">
+        <footer class="py-5 bg-dark">
             <div class="container px-5"><p class="m-0 text-center text-white small">Copyright &copy; Your Website 2021</p></div>
         </footer>
         <!-- Bootstrap core JS-->

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -89,7 +89,7 @@ html(lang='en')
                                 | Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod aliquid, mollitia odio veniam sit iste esse assumenda amet aperiam exercitationem, ea animi blanditiis recusandae! Ratione voluptatum molestiae adipisci, beatae obcaecati.
 
         // Footer
-        footer.py-5.bg-black
+        footer.py-5.bg-dark
             .container.px-5
                 p.m-0.text-center.text-white.small Copyright &copy; Your Website 2021
 


### PR DESCRIPTION
As reported by #58, the footer is missing as a result of an incorrectly referenced `bg-black` class. This PR fixes it by changing it to `bg-dark`.